### PR TITLE
Fix get_closure function signature for php74

### DIFF
--- a/zend/classimpl.cpp
+++ b/zend/classimpl.cpp
@@ -285,7 +285,11 @@ zend_function *ClassImpl::getStaticMethod(zend_class_entry *entry, zend_string *
  *  @param  object_ptr
  *  @return int
  */
+#if PHP_VERSION_ID < 80000
+int ClassImpl::getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry_ptr, zend_function **func, zend_object **object_ptr)
+#else
 int ClassImpl::getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry_ptr, zend_function **func, zend_object **object_ptr, zend_bool check_only)
+#endif
 {
     // it is really unbelievable how the Zend engine manages to implement every feature
     // in a complete different manner. You would expect the __invoke() and the

--- a/zend/classimpl.h
+++ b/zend/classimpl.h
@@ -328,7 +328,11 @@ public:
      *  @param  object_ptr  To be filled with the object on which the method is to be called
      *  @return int
      */
+#if PHP_VERSION_ID < 80000
+    static int getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry, zend_function **func, zend_object **object_ptr);
+#else
     static int getClosure(ZEND_OBJECT_OR_ZVAL object, zend_class_entry **entry, zend_function **func, zend_object **object_ptr, zend_bool check_only);
+#endif
 
     /**
      *  Function to cast the object to a different type


### PR DESCRIPTION
Only php80 accepts the added parameter. Added a version check to avoid the additional parameter on php74.

>  i. get_closure() object handlers now accept an additional zend_bool parameter
     `check_only`. If it is true, the handler is called to check whether the
     object is callable; in this case the handler should not throw an exception.

Reference: https://github.com/php/php-src/blob/php-8.0.0/UPGRADING.INTERNALS