### PR TITLE
Add YAML validation workflow

### DIFF
--- a/.github/workflows/validate_yaml.yaml
+++ b/.github/workflows/validate_yaml.yaml
@@ -1,0 +1,20 @@
+# yamllint disable rule:line-length
+
+name: YAML Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate-yaml:
+    name: Validate YAML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run YAML linter
+        run: |
+          find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint -d relaxed

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
   - 7.3
   - 7.4
   - 8.0
-  - nightly 
+  - nightly
 
 
 # setting the env is the easiest, because it will mix with all the separate php versions (travis does this)


### PR DESCRIPTION
This will let us see if any of the next actions have invalid syntax: last time I checked GitHub didn't fail the build when there were YAML syntax errors. Instead it assumed that that workflow isn't enabled.